### PR TITLE
Initial version of cticker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: go
+  
+go:
+  - 1.9.x
+  - tip
+  - master
+
+install:
+  - go get github.com/stretchr/testify/assert
+  - go get -u gopkg.in/alecthomas/gometalinter.v1
+  - gometalinter.v1 --install
+
+script:
+  - go test -v -race ./...
+  - gometalinter.v1 ./...

--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+# go-cticker [![Go Report Card](https://goreportcard.com/badge/github.com/multiplay/go-cticker)](https://goreportcard.com/report/github.com/multiplay/go-cticker) [![License](https://img.shields.io/badge/license-BSD-blue.svg)](https://github.com/multiplay/go-cticker/blob/master/LICENSE) [![GoDoc](https://godoc.org/github.com/multiplay/go-cticker?status.svg)](https://godoc.org/github.com/multiplay/go-cticker) [![Build Status](https://travis-ci.org/multiplay/go-cticker.svg?branch=master)](https://travis-ci.org/multiplay/go-cticker)
+
+go-cticker is a [Go](http://golang.org/) library that provides a ticker which ticks according to wall clock and is reliable under clock drift and clock adjustments; that is if you ask it to tick on the minute it will ensure that it does so even if the underlying clock is inaccurate or gets adjusted.
+
+Features
+--------
+* Reliable under clock drift.
+* Reliable under clock adjustments.
+
+Installation
+------------
+```sh
+go get -u github.com/multiplay/go-cticker
+```
+
+Examples
+--------
+
+Using go-cticker is very much like time.NewTicker with the addition of an accuracy and start time.
+
+The following creates a ticker which ticks on the minute according the hosts wall clock with an accuracy of plus or minus one second.
+```go
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/multiplay/go-cticker"
+)
+
+func main() {
+	t := cticker.New(time.Minute, time.Second)
+	for tick := range t.C {
+		// Process tick
+		fmt.Println("tick:", tick)
+	}
+}
+```
+
+Documentation
+-------------
+- [GoDoc API Reference](http://godoc.org/github.com/multiplay/go-cticker).
+
+License
+-------
+go-cticker is available under the [BSD 2-Clause License](https://opensource.org/licenses/BSD-2-Clause).
+```

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,18 @@
+package cticker_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/multiplay/go-cticker"
+)
+
+// TODO(steve): remove this nolint when go tool vet is fixed.
+// nolint: vet
+func ExampleTicker() {
+	t := cticker.New(time.Minute, time.Second)
+	for tick := range t.C {
+		// Process tick
+		fmt.Println("tick:", tick)
+	}
+}

--- a/ticker.go
+++ b/ticker.go
@@ -1,0 +1,131 @@
+// Package cticker provides a ticker which ticks according to wall clock
+// instead of monotonic clock. It is reliable under both clock drift and
+// clock adjustments, that is if you ask it to tick on the minute it will
+// ensure that it does so even if the underlying clock is inaccurate or
+// gets adjusted.
+package cticker
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// ticker is an interface that allows us to mock the runtime ticker for
+// testing.
+type ticker interface {
+	Ch() <-chan time.Time
+	Stop()
+}
+
+// runtimeTicker wraps time.Ticker implementing ticker.
+type runtimeTicker struct {
+	*time.Ticker
+}
+
+func newRuntimeTicker(d time.Duration) ticker {
+	return &runtimeTicker{Ticker: time.NewTicker(d)}
+}
+
+// Ch implements ticker.
+func (t *runtimeTicker) Ch() <-chan time.Time {
+	return t.C
+}
+
+// newTicker is the method used to create a new ticker so we can mock it
+// for testing.
+var newTicker = newRuntimeTicker
+
+// Ticker holds a channel that delivers `ticks` on wall clock boundaries.
+// Unlike time.Ticker it will fire early if the clock is adjusted to an
+// earlier time, therefore it can be used for events which need to trigger
+// on wall clock boundaries e.g. every minute on the minute.
+type Ticker struct {
+	mtx    sync.Mutex
+	C      <-chan time.Time // The channel on which ticks are delivered.
+	d      time.Duration
+	a      time.Duration
+	done   chan struct{}
+	ticker ticker
+}
+
+// New returns a new Ticker containing a channel that will send the
+// time at d wall clock boundaries plus or minus accuracy.
+// It will drop ticks to make up for slow receivers.
+// The duration d must be greater than zero; if not, NewTicker will panic.
+// The accuracy must be greater than d; it not, NewTicker will panic.
+// Stop the ticker to release its associated resources.
+func New(d, accuracy time.Duration) *Ticker {
+	if d <= accuracy {
+		panic(fmt.Errorf("accuracy %v is not less than duration %v", accuracy, d))
+	}
+	// We hold one element time buffer, if the consumer falls behind
+	// while reading the values, we drop the ticks until it catches
+	// back up.
+	c := make(chan time.Time, 1)
+	t := &Ticker{
+		C:    c,
+		d:    d,
+		a:    accuracy,
+		done: make(chan struct{}),
+	}
+
+	go func() {
+		// Synchronise to the accuracy.
+		now := time.Now()
+		time.Sleep(now.Truncate(accuracy).Add(accuracy).Sub(now))
+
+		t.mtx.Lock()
+		defer t.mtx.Unlock()
+		select {
+		case <-t.done:
+			// Already stopped
+		default:
+			t.ticker = newTicker(accuracy)
+			go t.tick(c)
+		}
+
+	}()
+
+	return t
+}
+
+// Stop turns off the ticker. After Stop, no more ticks will be sent.
+// Stop does not close the channel to prevent a read from the channel
+// succeeding incorrectly.
+func (t *Ticker) Stop() {
+	t.mtx.Lock()
+	defer t.mtx.Unlock()
+
+	close(t.done)
+	if t.ticker != nil {
+		t.ticker.Stop()
+	}
+}
+
+// tick sends ticks to t.C with the tickers defined accuracy.
+func (t *Ticker) tick(c chan time.Time) {
+	ticks := t.ticker.Ch()
+	var last time.Time
+	for {
+		select {
+		case now := <-ticks:
+			// Remove monotonic clock as we want wall clock comparisons.
+			now = now.Truncate(t.a)
+			tick := now.Truncate(t.d)
+
+			// Tick if we match the expected value or we're out by accuracy and
+			// we haven't ticked for that time.
+			if now.Equal(tick) || (!last.Equal(tick) && now.Add(-t.a).Equal(tick)) {
+				last = tick
+				select {
+				case c <- now:
+				default:
+					// Consumer is running slowly
+				}
+			}
+		case <-t.done:
+			return
+		}
+	}
+}

--- a/ticker_test.go
+++ b/ticker_test.go
@@ -1,0 +1,163 @@
+package cticker
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockTicker struct {
+	c      chan time.Time
+	done   chan struct{}
+	period time.Duration
+	times  []time.Time
+}
+
+func (t *mockTicker) run() {
+	tick := time.NewTicker(t.period)
+	defer tick.Stop()
+
+	for _, tm := range t.times {
+		select {
+		case <-tick.C:
+			t.c <- tm
+		case <-t.done:
+			return
+		}
+	}
+}
+
+func (t *mockTicker) Ch() <-chan time.Time {
+	return t.c
+}
+
+func (t *mockTicker) Stop() {
+	close(t.done)
+}
+
+func testSetup() (time.Duration, time.Duration, time.Time) {
+	d := time.Minute
+	a := time.Second
+	now := time.Now()
+
+	// Ensure we won't trigger the missed tick on the first value.
+	if now.Truncate(a).Add(-a).Equal(now.Truncate(d)) {
+		now = now.Add(a * 2)
+	}
+
+	return d, a, now
+}
+
+// TestTickerDrift checks that Ticker ticks based on the 'values' returned
+// by the underlying ticker, confirming it will adjust to clock drifts.
+func TestTickerDrift(t *testing.T) {
+	d, a, now := testSetup()
+
+	times := make([]time.Time, 0, 4*d/time.Second)
+	times = addTimes(times, now, now.Add(time.Minute*4), a)
+
+	ticks := make([]time.Time, 0, 4)
+	ticks = addTicks(ticks, now, now.Add(time.Minute*3), d, a)
+
+	last := testTicker(t, now, d, a, times, ticks)
+	now = time.Now()
+	assert.True(t, now.Before(last), fmt.Sprintln(now, "is not before", last))
+}
+
+// TestTickerAdjustment checks that Ticker deals with clock adjustments.
+func TestTickerAdjustment(t *testing.T) {
+	d, a, now := testSetup()
+	summer := now.Add(-time.Hour)
+
+	times := make([]time.Time, 0, 4*d/a)
+	times = addTimes(times, now, now.Add(time.Minute), a)
+	times = addTimes(times, summer.Add(d*2), summer.Add(d*5), a)
+
+	ticks := make([]time.Time, 0, 4)
+	ticks = append(ticks, now.Truncate(d).Add(d))
+	ticks = addTicks(ticks, summer.Add(d*2), summer.Add(d*4), d, a)
+
+	last := testTicker(t, now, d, a, times, ticks)
+	now = time.Now()
+	assert.True(t, now.After(last), fmt.Sprintln(now, "is not after", last))
+}
+
+// TestTickerLostTick checks that Ticker deals with clock adjustments
+// which result in the underlying tick that we would tick on being missed.
+func TestTickerLostTick(t *testing.T) {
+	d, a, now := testSetup()
+
+	times := make([]time.Time, 0, d/a)
+	times = addTimes(times, now, now.Add(time.Minute*4), a)
+
+	ticks := make([]time.Time, 0, 4)
+	ticks = addTicks(ticks, now, now.Add(time.Minute*3), d, a)
+
+	// Remove the time which would match the first tick
+	for i, t := range times {
+		if t.Truncate(d) == ticks[0] {
+			times = append(times[:i], times[i+1:]...)
+			ticks[0] = ticks[0].Add(a)
+			break
+		}
+	}
+
+	last := testTicker(t, now, d, a, times, ticks)
+	now = time.Now()
+	assert.True(t, now.Before(last), fmt.Sprintln(now, "is not before", last))
+}
+
+// addTimes adds underlying times that we will replay to times and returns the resultant slice.
+func addTimes(times []time.Time, start, end time.Time, a time.Duration) []time.Time {
+	for tick := start; tick.Before(end) || tick.Equal(end); tick = tick.Add(a) {
+		times = append(times, tick)
+	}
+
+	return times
+}
+
+// addTicks adds the expected ticks to ticks and returns the resultant slice.
+func addTicks(ticks []time.Time, start, end time.Time, d, a time.Duration) []time.Time {
+	for tick := start; tick.Before(end) || tick.Equal(end); tick = tick.Add(d) {
+		t := tick.Truncate(d)
+		if t.Equal(tick.Truncate(a)) {
+			// On tick
+			ticks = append(ticks, t)
+		} else {
+			// After the tick
+			ticks = append(ticks, t.Add(d))
+		}
+	}
+	return ticks
+}
+
+func testTicker(t *testing.T, now time.Time, d, a time.Duration, times, ticks []time.Time) time.Time {
+	newTicker = func(d time.Duration) ticker {
+		t := &mockTicker{
+			c:      make(chan time.Time, 4),
+			done:   make(chan struct{}),
+			period: time.Millisecond,
+			times:  times,
+		}
+		go t.run()
+		return t
+	}
+
+	tk := New(d, a)
+	defer tk.Stop()
+
+	var i int
+	var tick time.Time
+	for {
+		tick = <-tk.C
+		assert.Equal(t, ticks[i], tick)
+		i++
+		if i == len(ticks) {
+			break
+		}
+	}
+
+	return tick
+}


### PR DESCRIPTION
Initial version of cticker which is a library that provides a ticker which is reliable under clock drift and clock adjustments, that is if you ask it to tick on the minute it will ensure that it does so even if the underlying clock is inaccurate or gets adjusted.